### PR TITLE
Update soc.php

### DIFF
--- a/lp1/soc.php
+++ b/lp1/soc.php
@@ -1,4 +1,4 @@
-!/usr/bin/php
+#!/usr/bin/php
 <?php
 
 # erzeugt soc.txt asyncron da es laenger dauerk kann

--- a/lp1/soc.php
+++ b/lp1/soc.php
@@ -1,3 +1,4 @@
+!/usr/bin/php
 <?php
 
 # erzeugt soc.txt asyncron da es laenger dauerk kann

--- a/lp1/soc.php
+++ b/lp1/soc.php
@@ -11,7 +11,7 @@ exec("./soc_citigo/getsoc.sh >./soc_citigo/getsoc.log 2>&1 & ", $output,$retval)
 
  # Nehme letzten ermittelten Wert mit zurueck, 
  # warte nicht auf das Ende der aktuellen abfrage
- $soc  = file_get_contents('./soc.txt');
+ $soc  = file_get_contents ('./soc.txt');
  echo $soc
 
 ?>


### PR DESCRIPTION
Kleine Änderung. Nun läuft das Script bei mir wieder.

Ausführung des Scripts brachte in meinem Fall die Ausgabe:

pi@raspberrypi:/var/www/html/lp1 $ ./soc.php
./soc.php: Zeile 1: ?php: Datei oder Verzeichnis nicht gefunden
./soc.php: Zeile 6: Syntaxfehler beim unerwarteten Wort `"./soc_citigo/getsoc.sh >./soc_citigo/getsoc.log 2>&1 & ",'
./soc.php: Zeile 6: `exec("./soc_citigo/getsoc.sh >./soc_citigo/getsoc.log 2>&1 & ", $output,$retval);'

Nach Einfügen von "!/usr/bin/php" in Zeile 1 des Scripts, lief dieses wieder fehlerfrei:

pi@raspberrypi:/var/www/html/lp1 $ ./soc.php
85

Bitte prüfen, ich bin kein Programmierer und der Tip kam aus dem Internet.